### PR TITLE
Fix upcoming courses response handling

### DIFF
--- a/src/pages/UpcomingCourses.tsx
+++ b/src/pages/UpcomingCourses.tsx
@@ -10,7 +10,9 @@ const fetchCourses = async (): Promise<Course[]> => {
   );
   if (!res.ok) throw new Error("Failed fetching courses");
   const data = await res.json();
-  return data;
+  // Some API versions wrap the courses array in a `courses` or `data` key.
+  // Fallback to the raw response if neither wrapper exists.
+  return data.courses ?? data.data ?? data;
 };
 
 const UpcomingCourses = () => {
@@ -19,7 +21,7 @@ const UpcomingCourses = () => {
     queryFn: fetchCourses,
   });
 
-  const courses = data?.slice(0, 3) || [];
+  const courses = Array.isArray(data) ? data.slice(0, 3) : [];
 
   return (
     <div className="min-h-screen bg-background font-inter">


### PR DESCRIPTION
## Summary
- handle possible API response wrappers in UpcomingCourses page
- guard against invalid `courses` data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6877a6f3bd44832aba9064e5fb2c1a0a